### PR TITLE
OKTETO_REPOSITORY taken from origin when multiple remote configured

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -6,7 +6,7 @@ tasks:
       set +x;clear
 
       export OKTETO_BRANCH=$(git branch -v | awk '{print $2}')
-      export OKTETO_REPOSITORY=$(git remote -v | grep \(push\) | awk '{print $2}')
+      export OKTETO_REPOSITORY=$(git remote -v | grep 'origin.*\(push\)' | awk '{print $2}')
 
       [ ${OKTETO_TOKEN:-none} == 'none' ] && echo "OKTETO_TOKEN Not set!              This will surely cause issues below...." 
       [ ${OKTETO_USER:-none} == 'none' ] && echo "OKTETO_USER Not set!                This will surely cause issues below...." 


### PR DESCRIPTION
it worked but something I noticed weird

when I execute build function got "No such file or directory'
But when execute the line in build function it worked well.
```
gitpod /workspace/bob $ build
 ✓  Pipeline 'bob' started
bash: https://github.com/BobDotMe/bob.git: No such file or directory
gitpod /workspace/bob $ okteto pipeline deploy  --repository ${OKTETO_REPOSITORY} --branch ${OKTETO_BRANCH}
 ✓  Pipeline 'bob' started
gitpod /workspace/bob $ build
 ✓  Pipeline 'bob' started
bash: https://github.com/BobDotMe/bob.git: No such file or directory
gitpod /workspace/bob $ okteto pipeline deploy  --repository ${OKTETO_REPOSITORY} --branch ${OKTETO_BRANCH}
 ✓  Pipeline 'bob' started
gitpod /workspace/bob $ 
```